### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ An MCP server that detects potential honeypot tokens on Ethereum, BNB Smart Chai
 
 > **Honeypot** is a type of fraudulent smart contract that allows users to buy tokens but prevents them from selling or makes selling extremely difficult.
 
+<a href="https://glama.ai/mcp/servers/@kukapay/honeypot-detector-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kukapay/honeypot-detector-mcp/badge" alt="honeypot-detector-mcp MCP server" />
+</a>
+
 ![GitHub License](https://img.shields.io/github/license/kukapay/honeypot-detector-mcp) 
 ![Python Version](https://img.shields.io/badge/python-3.10%2B-blue)
 ![Status](https://img.shields.io/badge/status-active-brightgreen.svg)
@@ -88,4 +92,3 @@ Please check if the token at address 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
-


### PR DESCRIPTION
This PR adds a badge for the [honeypot-detector-mcp](https://glama.ai/mcp/servers/@kukapay/honeypot-detector-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kukapay/honeypot-detector-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kukapay/honeypot-detector-mcp/badge" alt="honeypot-detector-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.